### PR TITLE
Touches relevant models on change to invalidate some caches

### DIFF
--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -7,7 +7,7 @@ class Package < ActiveRecord::Base
   include HasAnIcon
 
   # Dependancy relationships
-  belongs_to :package_branch
+  belongs_to :package_branch, :touch => true
   belongs_to :icon
 
   has_many :dependents, :class_name => "RequireItem", :dependent => :destroy

--- a/app/models/package_branch.rb
+++ b/app/models/package_branch.rb
@@ -6,10 +6,10 @@ class PackageBranch < ActiveRecord::Base
   validates_presence_of :name, :display_name, :package_category_id
   validates_uniqueness_of :name, :scope => [:unit_id]
   validates_format_of :name, :with => /^[^ -.]+$/, :message => "must not contain spaces or hyphens or dots"
-  
+
   attr_accessible :name, :display_name, :package_category_id
   attr_accessor :environment_id
-  
+
   # Relationships
   has_many :install_items, :dependent => :destroy
   has_many :uninstall_items, :dependent => :destroy
@@ -21,8 +21,8 @@ class PackageBranch < ActiveRecord::Base
   has_many :packages, :order => "version DESC", :dependent => :destroy
   has_many :shared_packages, :class_name => "Package", :conditions => {:shared => true}
   has_one :version_tracker, :dependent => :destroy, :autosave => true
-  
-  belongs_to :package_category
+
+  belongs_to :package_category, :touch => true
 
   scope :find_for_index, lambda {|unit, env| has_versions.unit(unit).environment(env).order("name ASC").includes({:packages => [:environment, :package_branch]}, :package_category) }
   scope :environment, lambda {|env| joins(:packages).where(:packages => {:environment_id => env.id}).uniq }
@@ -35,9 +35,9 @@ class PackageBranch < ActiveRecord::Base
   def self.conform_to_name_constraints(name)
     name.gsub(/[^A-Za-z0-9_]+/,"_")
   end
-  
-  # Check if there exists a pacakge branch display name that matches the 
-  # current package branch name, if found, return a new package branch 
+
+  # Check if there exists a pacakge branch display name that matches the
+  # current package branch name, if found, return a new package branch
   # display name follow by appending time stamp
   def self.conform_to_display_name_constraints(display_name,id)
     if PackageBranch.where(:display_name => display_name).where("id <> ?", id.to_i).present?
@@ -46,41 +46,41 @@ class PackageBranch < ActiveRecord::Base
       display_name
     end
   end
-  
+
   def latest
     packages.limit(1).first
   end
-  
+
   # Get the latest package within a unit and environment
   def latest_where_unit_and_environment(unit,env)
     latest_where_unit(unit).where(:environment_id => env.id)
   end
-  
+
   def latest_where_unit(unit)
     packages.where(:unit_id => unit.id).order('version desc').limit(1).first
   end
-  
+
   # Extends the functionality of the association dynamic method to
   # return only the packages that match the passed unit member
   def packages_like_unit_member(um)
     packages.where(:environment_id => um.environment_id, :unit_id => um.unit_id)
   end
-  
+
   def packages_where_unit_and_environment(unit,environment)
     packages.where(:environment_id => environment.id, :unit_id => unit.id)
   end
-  
+
   # Return all the packages that are shared and from the given unit
   def shared_packages_from_unit(unit)
     Package.shared.where(:package_branch_id => id, :unit_id => unit.id).order("version DESC")
   end
-  
+
   # Virtual attribute that retrieves the web ID from the version tracker
   # record associated to this package branch
   def version_tracker_web_id
     version_tracker.web_id = version_tracker.web_id unless version_tracker.nil?
   end
-  
+
   def version_tracker_web_id=(value)
     version_tracker.web_id = value unless version_tracker.nil?
   end
@@ -89,11 +89,11 @@ class PackageBranch < ActiveRecord::Base
   def version_tracker_web_url
     version_tracker.download_url unless version_tracker.nil?
   end
-  
+
   def version_tracker_web_url=(url)
     version_tracker.download_url = url unless version_tracker.nil?
   end
-  
+
   # True if a newer version is available in this branch
   def new_version?(unit = nil)
     if version_tracker.nil? or version_tracker.version.nil?
@@ -107,14 +107,14 @@ class PackageBranch < ActiveRecord::Base
       end
     end
   end
-  
+
   # Returns latest package or package with
   # ID of arg 1 (if it exists)
   def package(unit_member = nil, id = nil)
     p = packages
 
     # Specify a certain ID
-    p = p.where(:id => id) unless id.nil?    
+    p = p.where(:id => id) unless id.nil?
 
     # Limiting scope to that of unit_member or current scope (defined by unit_id and environment_id)
     if unit_member != nil
@@ -126,18 +126,18 @@ class PackageBranch < ActiveRecord::Base
     end
     p.first
   end
-  
+
   # Grabs vtv from latest package
   def vtv(unit = nil)
     p = unit.present? ? latest_where_unit(unit) : latest
     p.vtv unless p.nil?
   end
-  
+
   # Get the associated environment
   def environment
     Environment.find_by_id(@environment_id)
   end
-  
+
   # True if there is a newer version of in this package branch
   # available from a unit different than unit
   def new_version_shared?(unit)
@@ -152,14 +152,14 @@ class PackageBranch < ActiveRecord::Base
       false
     end
   end
-  
-  # Gets packages that have available updates.  If no unit is 
+
+  # Gets packages that have available updates.  If no unit is
   # specified, all units are inspected.
   def self.available_updates(unit = nil)
     packages_with_updates = []
     if unit.present?
       latest_packages = Package.latest_where_unit(unit)
-      packages_with_updates = latest_packages.delete_if {|p| p.nil? or !p.new_version? }      
+      packages_with_updates = latest_packages.delete_if {|p| p.nil? or !p.new_version? }
     else
       Unit.all.each do |unit|
         latest_packages = Package.latest_where_unit(unit)
@@ -168,48 +168,48 @@ class PackageBranch < ActiveRecord::Base
     end
     packages_with_updates
   end
-  
+
   def self.cached_available_updates(unit = nil)
     Rails.cache.fetch("available-updates-for-unit-id-#{unit.id}", :expires_in => 4.hours) do
       self.available_updates(unit)
     end
   end
-  
+
   # Return the package branches available to a given unit member
-  # Doesn't return an ActiveRecord::Relation (search cannot be 
+  # Doesn't return an ActiveRecord::Relation (search cannot be
   # done using only SQL)
   def self.unit_member(unit_member)
     Package.unit(unit_member.unit).environments(unit_member.environments).map { |e| e.package_branch }.uniq
   end
-  
+
   # Get package branches with packages in a specified unit and environment
   # TO-DO Not very efficient, could be refactored
   def self.unit_and_environment(unit,environment)
     Package.unit(unit).environment(environment).uniq_by {|package| package.package_branch_id }
   end
-  
+
   # Overrides default to string method.  Specifies version if this package
   # isn't the latest of the current units
-  def to_s(style = nil)    
+  def to_s(style = nil)
     case style
       when :pretty then display_name
       else name
     end
   end
-  
+
   def to_param
     name
   end
-  
+
   def to_params
     {:unit_shortname => unit.shortname,
      :name => name}
   end
-  
+
   def obsolete?
     packages.empty? and install_items.empty? and uninstall_items.empty? and managed_update_items.empty? and optional_install_items.empty? and require_items.empty? and update_for_items.empty?
   end
-  
+
   def icon
     icon = version_tracker.icon unless version_tracker.nil?
     icon ||= package_category.icon

--- a/app/views/packages/_package_table_row.html.erb
+++ b/app/views/packages/_package_table_row.html.erb
@@ -10,12 +10,10 @@
     <%= render :partial => "packages/package_version_column", :locals => {:pkg => packages.first} %>
   </tr>
   <% packages.each_with_index do |package, i| %>
-    <% cache(package) do %>
-      <% unless i == 0 %>
-        <tr>
-          <%= render :partial => 'packages/package_version_column', :locals => {:pkg => package} %>
-        </tr>
-      <% end %>
-    <% end %>
+  <% unless i == 0 %>
+  <tr>
+    <%= render :partial => 'packages/package_version_column', :locals => {:pkg => package} %>
+  </tr>
+  <% end %>
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -78,5 +78,6 @@ module Munki
     # end
 
     config.action_mailer.raise_delivery_errors = false
+
   end
 end


### PR DESCRIPTION
Also no longer caches package version columns as they were problematic

(a nice topping of whitespace trashing; you're welcome)

@rickychilcott 
