### PR TITLE
Prevent errors when bulk updating packages (changing environments)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,9 +54,7 @@ group :assets do
   gem 'uglifier'
 end
 
-group :production do
-  gem 'newrelic_rpm'
-end
+gem 'newrelic_rpm'
 
 gem 'pry-rails', :group => [:development, :test]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
     mini_portile (0.5.0)
     multi_json (1.11.2)
     mysql2 (0.3.20)
-    newrelic_rpm (3.14.0.305)
+    newrelic_rpm (3.14.1.311)
     nokogiri (1.6.0)
       mini_portile (~> 0.5.0)
     open_uri_redirections (0.2.1)
@@ -329,4 +329,4 @@ DEPENDENCIES
   will_paginate (~> 3.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.1

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -98,22 +98,12 @@ class PackagesController < ApplicationController
     end
     respond_to do |format|
       flash[:error] = results[:messages].join('</br>').html_safe if results[:messages]
+      flash[:error] += exceptionMessage if exceptionMessage
       if results[:successes] == results[:total]
         flash[:notice] = "All #{results[:total]} #{'package'.pluralize if results[:total] > 1} were updated successfully"
       else
         flash[:warning] = "#{results[:successes]} #{'package'.pluralize if results[:successes] > 1} of #{results[:total]} #{'package'.pluralize if results[:total] > 1} were updated."
       end
-#      if exceptionMessage
-#        flash[:error] = "A problem occurred: " + exceptionMessage
-#      elsif results[:total] == results[:successes] and results[:failures] == 0
-#        flash[:notice] = "All #{results[:total]} packages were successfully updated."
-#      elsif results[:total] == results[:failures] and results[:successes] == 0
-#        flash[:error] = "None of the #{results[:total]} packages were updated!"
-#      elsif results[:successes] > 0 and results[:failures] > 0
-#        flash[:warning] = "#{results[:successes]} of #{results[:total]} packages updated."
-#      else
-#        flash[:error] = "Something weird happened. Here are the results: #{results.inspect}"
-#      end
       format.html { redirect_to packages_path }
     end
   end

--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -97,17 +97,23 @@ class PackagesController < ApplicationController
       exceptionMessage = e.to_s
     end
     respond_to do |format|
-      if exceptionMessage
-        flash[:error] = "A problem occurred: " + exceptionMessage
-      elsif results[:total] == results[:successes] and results[:failures] == 0
-        flash[:notice] = "All #{results[:total]} packages were successfully updated."
-      elsif results[:total] == results[:failures] and results[:successes] == 0
-        flash[:error] = "None of the #{results[:total]} packages were updated!"
-      elsif results[:successes] > 0 and results[:failures] > 0
-        flash[:warning] = "#{results[:successes]} of #{results[:total]} packages updated."
+      flash[:error] = results[:messages].join('</br>').html_safe if results[:messages]
+      if results[:successes] == results[:total]
+        flash[:notice] = "All #{results[:total]} #{'package'.pluralize if results[:total] > 1} were updated successfully"
       else
-        flash[:error] = "Something weird happened. Here are the results: #{results.inspect}"
+        flash[:warning] = "#{results[:successes]} #{'package'.pluralize if results[:successes] > 1} of #{results[:total]} #{'package'.pluralize if results[:total] > 1} were updated."
       end
+#      if exceptionMessage
+#        flash[:error] = "A problem occurred: " + exceptionMessage
+#      elsif results[:total] == results[:successes] and results[:failures] == 0
+#        flash[:notice] = "All #{results[:total]} packages were successfully updated."
+#      elsif results[:total] == results[:failures] and results[:successes] == 0
+#        flash[:error] = "None of the #{results[:total]} packages were updated!"
+#      elsif results[:successes] > 0 and results[:failures] > 0
+#        flash[:warning] = "#{results[:successes]} of #{results[:total]} packages updated."
+#      else
+#        flash[:error] = "Something weird happened. Here are the results: #{results.inspect}"
+#      end
       format.html { redirect_to packages_path }
     end
   end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -53,6 +53,16 @@ class Package < ActiveRecord::Base
   validates_uniqueness_of :version, :scope => [:unit_id, :package_branch_id]
   validates :force_install_after_date_string, :date_time => true, :allow_blank => true
 
+  # Update For and Requires must be in the same environment as the record
+  validates_each :update_for_items, :require_items do |record, attr, items|
+    items.each do |item| 
+      unless record.environment == item.package.environment
+        pretty_name = attr.to_s.gsub(/_/, ' ').titleize
+        record.errors.add(attr, "#{pretty_name} must be in the same environment as the package it is for.")
+      end
+    end
+  end
+
   FORM_OPTIONS = {:restart_actions         => [['None','None'],['Logout','RequireLogout'],['Restart','RequireRestart'],['Recommend Restart','RecommendRestart']],
                   :os_versions             => [[['Any','']], os_range(10,11,0..1), os_range(10,10,0..5), os_range(10,9,0..5), os_range(10,8,0..5), os_range(10,7,0..5), os_range(10,6,0..8), os_range(10,5,0..11)].flatten(1),
                   :installer_types         => [['Package',''],
@@ -721,8 +731,8 @@ class Package < ActiveRecord::Base
       results = packages.map do |p|
         p.update_attributes(package_attributes)
       end
-      successes = results.map {|b| b == false }
-      failures = results.map {|b| b == true }
+      successes = results.select {|b| b }
+      failures = results.select {|b| not b }
       {:total => packages.count, :successes => successes.count, :failures => failures.count}
     end
   end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -58,7 +58,7 @@ class Package < ActiveRecord::Base
     items.each do |item| 
       unless record.environment == item.package.environment
         pretty_name = attr.to_s.gsub(/_/, ' ').titleize
-        record.errors.add(attr, "#{pretty_name} must be in the same environment as the package it is for.")
+        record.errors.add(attr, "#{pretty_name} must be in the same environment as the package they are for.")
       end
     end
   end

--- a/app/models/package.rb
+++ b/app/models/package.rb
@@ -54,11 +54,11 @@ class Package < ActiveRecord::Base
   validates :force_install_after_date_string, :date_time => true, :allow_blank => true
 
   # Update For and Requires must be in the same environment as the record
-  validates_each :update_for_items, :require_items do |record, attr, items|
+  validates_each :update_for_items, :require_items do |package, attr, items|
     items.each do |item| 
-      unless record.environment == item.package.environment
+      unless package.environment == item.package.environment
         pretty_name = attr.to_s.gsub(/_/, ' ').titleize
-        record.errors.add(attr, "#{pretty_name} must be in the same environment as the package they are for. (#{record.name})")
+        package.errors.add(attr, "#{pretty_name} must be in the same environment as the package they are for. (#{package.name})")
       end
     end
   end


### PR DESCRIPTION
This addresses a bug where bulk editing packages could lead to a package that had `update_for_items` or `required_items` from a different environment.

Also fixes an issue in the `Package.bulk_update_attributes` code where the counts of `successes` and `failures` were incorrect.

@rickychilcott 
